### PR TITLE
Switch signup email input to use HTML5 email type to save mobile browsers a tap or two.

### DIFF
--- a/bookie/static/css/responsive.scss
+++ b/bookie/static/css/responsive.scss
@@ -190,7 +190,7 @@
             }
         }
 
-        input[type=text], input[type="url"], input[type="password"], textarea {
+        input[type=text], input[type="email"], input[type="url"], input[type="password"], textarea {
             display: block;
             width: 100%;
             padding: 5px;

--- a/bookie/templates/auth/signup.mako
+++ b/bookie/templates/auth/signup.mako
@@ -20,7 +20,7 @@
                 <ul>
                     <li>
                         <label>Email Address</label>
-                        <input type="text" id="email" name="email" />
+                        <input type="email" id="email" name="email" />
                         <input type="submit" id="send_signup" name="send_signup" value="Sign Up" />
                     </li>
                 </ul>


### PR DESCRIPTION
I'm not entirely certain I did the SCSS stuff right - but I was trying to preserve what the input looks like by adding the new type to the same rule it used before.
