### PR TITLE
Use HTML5 email inputs for emails to save mobile browsers a couple taps.

### DIFF
--- a/bookie/static/css/responsive.scss
+++ b/bookie/static/css/responsive.scss
@@ -190,7 +190,7 @@
             }
         }
 
-        input[type=text], input[type="url"], input[type="password"], textarea {
+        input[type=text], input[type="email"], input[type="url"], input[type="password"], textarea {
             display: block;
             width: 100%;
             padding: 5px;

--- a/bookie/templates/accounts/index.mako
+++ b/bookie/templates/accounts/index.mako
@@ -43,7 +43,7 @@ ${account_nav()}
                 </li>
                 <li>
                     <label>Email</label>
-                    <input type="text" id="email" name="email" value="${user.email}" />
+                    <input type="email" id="email" name="email" value="${user.email}" />
                 </li>
                 <li>
                     <label></label>

--- a/bookie/templates/auth/forgot.mako
+++ b/bookie/templates/auth/forgot.mako
@@ -4,7 +4,7 @@
             <ul>
                 <li>
                     <label>Email</label>
-                    <input type="text" id="email" name="email" value="" />
+                    <input type="email" id="email" name="email" value="" />
                 </li>
                 <li>
                     <label></label>

--- a/bookie/templates/auth/signup.mako
+++ b/bookie/templates/auth/signup.mako
@@ -20,7 +20,7 @@
                 <ul>
                     <li>
                         <label>Email Address</label>
-                        <input type="text" id="email" name="email" />
+                        <input type="email" id="email" name="email" />
                         <input type="submit" id="send_signup" name="send_signup" value="Sign Up" />
                     </li>
                 </ul>

--- a/bookie/templates/jstpl.mako
+++ b/bookie/templates/jstpl.mako
@@ -124,7 +124,7 @@
                 <ul>
                     <li>
                         <label>Email Address</label>
-                        <input type="text" id="invite_email" name="invite_email" />
+                        <input type="email" id="invite_email" name="invite_email" />
                         <input type="submit" id="send_invite" name="send_invite" value="Send" />
                     </li>
                 </ul>


### PR DESCRIPTION
I'm not sure about the SCSS change - the idea was to use the same rule as the existing text input so that the forms look the same.
