### PR TITLE
Allow non-interactive `make sysdeps`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,11 @@ clean_all: clean_venv clean_js clean_css clean_chrome clean_downloadcache
 
 .PHONY: sysdeps
 sysdeps:
-	sudo apt-get install $(SYSDEPS)
+	if [ $(NONINTERACTIVE) ]; then \
+		sudo apt-get install -y $(SYSDEPS); \
+	else \
+		sudo apt-get install $(SYSDEPS); \
+	fi
 
 .PHONY: install
 install: $(BOOKIE_INI) all first_bookmark css


### PR DESCRIPTION
I was working on a Vagrant script that would fire up and provision a VM automatically so I could run Bookie. This change will allow my provisioner to install the system dependencies without prompting me to confirm.
