### PR TITLE
Add `origin master` to git pull for download-cache

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -130,7 +130,7 @@ lint:
 deps: venv
 	@echo "\n\nSilently installing packages (this will take a while)..."
 	if test -d download-cache; \
-		then cd download-cache && git pull || true; \
+		then cd download-cache && git pull origin master || true; \
 		else git clone --depth=1 "http://github.com/mitechie/bookie-download-cache.git" download-cache; \
 	fi
 	@echo "Making sure the latest version of pip is available"


### PR DESCRIPTION
When building my 12.04 Vagrant box, it was not pulling the bookie-download-cache repo. Specifying the remote and branch in the command fixed it.
