### PR TITLE
Handle exception when adding a bmark w/o url

### DIFF
--- a/bookie/views/api.py
+++ b/bookie/views/api.py
@@ -173,7 +173,7 @@ def bmark_add(request):
             params = request.json_body
         else:
             raise ValueError('No url provided')
-    except ValueError, exc:
+    except ValueError:
         request.response.status_int = 400
         return _api_response(request, {
             'error': 'Bad Request: No url provided'

--- a/bookie/views/api.py
+++ b/bookie/views/api.py
@@ -166,15 +166,17 @@ def _update_mark(mark, params):
 def bmark_add(request):
     """Add a new bookmark to the system"""
     rdict = request.matchdict
-
-    if 'url' in request.params or 'hash_id' in request.params:
-        params = request.params
-    elif 'url' in request.json_body or 'hash_id' in request.json_body:
-        params = request.json_body
-    else:
+    try:
+        if 'url' in request.params or 'hash_id' in request.params:
+            params = request.params
+        elif 'url' in request.json_body or 'hash_id' in request.json_body:
+            params = request.json_body
+        else:
+            raise ValueError('No url provided')
+    except ValueError, exc:
         request.response.status_int = 400
         return _api_response(request, {
-            'error': 'Bad Request: missing url',
+            'error': 'Bad Request: No url provided'
         })
 
     user = request.user

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -24,6 +24,7 @@ Submit a new bookmark for storing
 
 :query param: api_key *required* - the api key for your account to make the call with
 :query param: callback - wrap JSON response in an optional callback
+:post param: url *required*
 :post param: description
 :post param: extended
 :post param: tags - space separated tag string


### PR DESCRIPTION
When doing an empty POST to /:username/bmark, Pyramid would throw an
exception ("No JSON object could be decoded").

Also, updated api docs to include required `url` param.
