### PR TITLE
Allow anonymous API requests for bmark_get

### DIFF
--- a/bookie/views/api.py
+++ b/bookie/views/api.py
@@ -91,7 +91,7 @@ def ping_missing_api(request):
 
 
 @view_config(route_name="api_bmark_hash", renderer="jsonp")
-@api_auth('api_key', UserMgr.get)
+@api_auth('api_key', UserMgr.get, anon=True)
 def bmark_get(request):
     """Return a bookmark requested via hash_id
 
@@ -103,7 +103,11 @@ def bmark_get(request):
     params = request.params
 
     hash_id = rdict.get('hash_id', None)
-    username = request.user.username
+
+    if request.user and request.user.username:
+        username = request.user.username
+    else:
+        username = None
 
     # the hash id will always be there or the route won't match
     bookmark = BmarkMgr.get_by_hash(hash_id,

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -74,7 +74,7 @@ Usage
 
 Get the information about this bookmark.
 
-:query param: api_key *required* - the api key for your account to make the call with
+:query param: api_key *optional* - the api key for your account to make the call with
 :query param: with_content - do you wish the readable content of the urls if available
 :query param: last_bmark - do you want the information of the last bookmark saved. This is used to supply tag hints in the Chrome extension.
 :query param: callback - wrap JSON response in an optional callback


### PR DESCRIPTION
Currently, GET /:username/bmark/:hash_id only allows you to access detail about your own bookmarks. I'd like to open it up so apps can get it, too.
