### PR TITLE
Fix to issue #295

### DIFF
--- a/CREDITS.txt
+++ b/CREDITS.txt
@@ -14,3 +14,4 @@ Thanks to these people that have contributed code/assistance to bookie
 - Jon Schewe
 - Cameron Macintosh
 - Ryan Kather
+- Saurabh Kathpalia

--- a/bookie/templates/bmark/edit.mako
+++ b/bookie/templates/bmark/edit.mako
@@ -151,6 +151,7 @@
                     console.log(data);
                     console.log(status_str);
                     console.log(response);
+                    indicator.hide();
                 }
             });
             % endif


### PR DESCRIPTION
If the server fails to load the information below the edit bookmark form then it would hide the loading bar which was earlier visible all the time
