### PR TITLE
explicitly create python2.7 virtualenv

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -378,7 +378,7 @@ stop_livereload:
 .PHONY: venv
 venv: bin/python
 bin/python:
-	virtualenv .
+	virtualenv -p python2 .
 
 .PHONY: clean_venv
 clean_venv:


### PR DESCRIPTION
The Makefile should explicitly create the virtualenv with python 2.7 since in newer versions of ubuntu the virtualenv defaults to a python 3.3 install.
