### PR TITLE
Chrome Storage implementation in place of local storage and option to enable/disable sync

### DIFF
--- a/bookie/static/js/bookie/model.js
+++ b/bookie/static/js/bookie/model.js
@@ -763,7 +763,6 @@ YUI.add('bookie-model', function (Y) {
                 }
                 that.set(key, ret);
 
-<<<<<<< HEAD
                 if(callback)
                     callback();
             }
@@ -779,7 +778,7 @@ YUI.add('bookie-model', function (Y) {
                     });
                 }
             }
-=======
+
             function onSyncRead(){
                 if (sync && (key === 'api_key' || key === 'api_username' || key === 'api_url' || key === 'cache_content')) {
                     chrome.storage.sync.get(key, function(object) {
@@ -791,7 +790,6 @@ YUI.add('bookie-model', function (Y) {
                     });
                 }
             }
->>>>>>> edfa42db8ae4549c502812e53c50c7b70218a365
             //found = localStorage.getItem(key);
         },
 

--- a/bookie/static/js/bookie/model.js
+++ b/bookie/static/js/bookie/model.js
@@ -741,9 +741,6 @@ YUI.add('bookie-model', function (Y) {
                 that = this,
                 sync;
 
-            // save the THIS object so that you can update it
-            // later in the async call returns
-
             chrome.storage.local.get('sync_config',function(obj){
                 sync = obj['sync_config'];
                 onSyncRead();
@@ -763,8 +760,10 @@ YUI.add('bookie-model', function (Y) {
                 }
                 that.set(key, ret);
 
-                if(callback)
+                if(callback){
                     callback();
+                }
+                    
             }
 
             function onSyncRead(){
@@ -790,7 +789,6 @@ YUI.add('bookie-model', function (Y) {
                     });
                 }
             }
-            //found = localStorage.getItem(key);
         },
 
         get_apicfg: function () {

--- a/bookie/static/js/bookie/model.js
+++ b/bookie/static/js/bookie/model.js
@@ -668,7 +668,7 @@ YUI.add('bookie-model', function (Y) {
             this._get_data('api_key', this.get('api_key'));
             this._get_data('cache_content', this.get('cache_content'));
             this._get_data('sync_config', this.get('sync_config'));
-            this._get_data('last_bmark', this.get('last_bmark'));
+            this._get_data('last_bmark', this.get('last_bmark'), callback);
         },
 
 
@@ -730,16 +730,21 @@ YUI.add('bookie-model', function (Y) {
          * @private
          *
          */
-        _get_data: function(key, def) {
+        _get_data: function(key, def, callback) {
 
             var ret,
                 found,
-                sync = this.get('sync_config'),
-                that = this;
+                that = this,
+                sync;
 
             // save the THIS object so that you can update it
             // later in the async call returns
 
+            chrome.storage.local.get('sync_config',function(obj){
+                sync = obj['sync_config'];
+                onSyncRead();
+            });
+            
             function update(object) {
                 if (object.hasOwnProperty(key)) {
                     found = object[key];
@@ -753,18 +758,22 @@ YUI.add('bookie-model', function (Y) {
                     ret = found;
                 }
                 that.set(key, ret);
+
+                if(callback)
+                    callback();
             }
 
-            if (sync && (key === 'api_key' || key === 'api_username' || key === 'api_url' || key === 'cache_content')) {
-                chrome.storage.sync.get(key, function(object) {
-                    update(object);
-                });
-            } else {
-                chrome.storage.local.get(key, function(object) {
-                    update(object);
-                });
+            function onSyncRead(){
+                if (sync && (key === 'api_key' || key === 'api_username' || key === 'api_url' || key === 'cache_content')) {
+                    chrome.storage.sync.get(key, function(object) {
+                        update(object);
+                    });
+                } else {
+                    chrome.storage.local.get(key, function(object) {
+                        update(object);
+                    });
+                }
             }
-
             //found = localStorage.getItem(key);
         },
 

--- a/bookie/static/js/bookie/model.js
+++ b/bookie/static/js/bookie/model.js
@@ -721,12 +721,16 @@ YUI.add('bookie-model', function (Y) {
         },
 
         /**
-         * A helper to getting data from localStorage, but using the passed in
-         * default if the key isn't found.
+         * A helper to set the ATTR corresponding to the requested key field. 
+         * Unlike localStorage, chrome.storage.local/sync is asynchronous. Instead of 
+         * returning the value from _get_data the function takes care of 
+         * setting the values once the async call returns. 
+         * 
+         * If the key is not found, default values are set.
          *
          * @method _get_data
          * @param {String} key
-         * @param def
+         * @param {String}def
          * @private
          *
          */

--- a/bookie/static/js/bookie/model.js
+++ b/bookie/static/js/bookie/model.js
@@ -663,14 +663,21 @@ YUI.add('bookie-model', function (Y) {
          *
          */
         _read: function(options, callback) {
-            this._get_data('api_url', this.get('api_url'));
-            this._get_data('api_username', this.get('api_username'));
-            this._get_data('api_key', this.get('api_key'));
-            this._get_data('cache_content', this.get('cache_content'));
-            this._get_data('sync_config', this.get('sync_config'));
-            this._get_data('last_bmark', this.get('last_bmark'), callback);
-        },
+            // At the moment, we request all of the variables at a stretch. 
+            // It maybe possible in the future to request any of these.
 
+            var keys = ['api_url', 'api_username', 'api_key', 'cache_content'];
+            var store = {
+                'api_url': this.get('api_url'),
+                'api_username': this.get('api_username'),
+                'api_key': this.get('api_key'),
+                'cache_content': this.get('cache_content'),
+                'sync_config': this.get('sync_config'),
+                'last_bmark': this.get('last_bmark'),
+            };
+
+            this._get_data(keys, store, callback);
+        },
 
         /**
          * Handle the save() event for objects that have an id and write it
@@ -712,80 +719,70 @@ YUI.add('bookie-model', function (Y) {
                 'last_bmark': this.get('last_bmark'),
                 'sync_config': sync
             });
-
-            // localStorage.setItem('api_url', this.get('api_url'));
-            // localStorage.setItem('api_username', this.get('api_username'));
-            // localStorage.setItem('api_key', this.get('api_key'));
-            // localStorage.setItem('cache_content', this.get('cache_content'));
-            // localStorage.setItem('last_bmark', this.get('last_bmark'));
         },
 
         /**
-         * A helper to set the ATTR corresponding to the requested key field. 
-         * Unlike localStorage, chrome.storage.local/sync is asynchronous. Instead of 
+         * A helper to set the ATTRS. Unlike localStorage, 
+         * chrome.storage.local/sync is asynchronous. Instead of 
          * returning the value from _get_data the function takes care of 
          * setting the values once the async call returns. 
          * 
-         * If the key is not found, default values are set.
+         * If any of the key in the array "keys" is not found, 
+         * values corresponding to that key in the object "store" is used. 
          *
          * @method _get_data
-         * @param {String} key
-         * @param {String}def
+         * @param {Array} keys
+         * @param {Object} store
+         * @param {Function} callback
          * @private
          *
          */
-        _get_data: function(key, def, callback) {
-
+        _get_data: function(keys, store, callback) {
+            // "store" is the object that contains a map of keys with
+            // their corresponding values from the memory.
             var ret,
                 found,
                 that = this,
                 sync;
 
-            chrome.storage.local.get('sync_config',function(obj){
-                sync = obj['sync_config'];
+            // The following keys are always stored in chrome.storage.local
+            chrome.storage.local.get(['sync_config', 'last_bmark'], function(object) {
+                data = Y.merge(object, data);
                 onSyncRead();
             });
-            
-            function update(object) {
-                if (object.hasOwnProperty(key)) {
-                    found = object[key];
-                } else {
-                    found = null;
-                }
 
-                if (found === null || found === undefined) {
-                    ret = def;
-                } else {
-                    ret = found;
-                }
-                that.set(key, ret);
+            function update() {
+                keys.push('sync_config', 'last_bmark'); 
+                Y.Array.each(keys, function(item, index, array) {
+                    if (data.hasOwnProperty(item)) {
+                        found = data[item];
+                    } else {
+                        found = null;
+                    }
 
-                if(callback){
+                    if (found === null || found === undefined) {
+                        ret = store[item];
+                    } else {
+                        ret = found;
+                    }
+                    that.set(item, ret);
+                });
+
+                if (callback) {
                     callback();
                 }
-                    
             }
 
-            function onSyncRead(){
-                if (sync && (key === 'api_key' || key === 'api_username' || key === 'api_url' || key === 'cache_content')) {
-                    chrome.storage.sync.get(key, function(object) {
-                        update(object);
+            function onSyncRead() {
+                if (data['sync_config']) {
+                    chrome.storage.sync.get(keys, function(object) {
+                        data = Y.merge(object, data);
+                        update();
                     });
                 } else {
-                    chrome.storage.local.get(key, function(object) {
-                        update(object);
-                    });
-                }
-            }
-
-            function onSyncRead(){
-                if (sync && (key === 'api_key' || key === 'api_username' || key === 'api_url' || key === 'cache_content')) {
-                    chrome.storage.sync.get(key, function(object) {
-                        update(object);
-                    });
-                } else {
-                    chrome.storage.local.get(key, function(object) {
-                        update(object);
+                    chrome.storage.local.get(keys, function(object) {
+                        data = Y.merge(object, data);
+                        update();
                     });
                 }
             }

--- a/bookie/static/js/bookie/model.js
+++ b/bookie/static/js/bookie/model.js
@@ -691,12 +691,10 @@ YUI.add('bookie-model', function (Y) {
          */
         _update: function(options, callback) {
 
-            // everything except last_bmark is synced based on the sync_config flag
-            // no error checking is done at this moment.
-            // check for runtime.lastError if writing to chrome.storage fails
-            // get the sync_config checkbox value
-            // before updating the local storage, the value is updated in the memory
-
+            // Everything except last_bmark is synced based on the sync_config flag
+            // No error checking is done at this moment. Check for runtime.lastError
+            // if writing to chrome.storage fails
+            // Based on the current selection, store in either chrome.storage.sync/local
             var sync = this.get('sync_config');
 
             if (sync) {

--- a/bookie/static/js/bookie/model.js
+++ b/bookie/static/js/bookie/model.js
@@ -734,13 +734,19 @@ YUI.add('bookie-model', function (Y) {
 
             var ret,
                 found,
-                sync = this.get('sync_config'),
-                that = this;
+                that = this,
+                sync;
 
             // save the THIS object so that you can update it
             // later in the async call returns
 
+            chrome.storage.local.get('sync_config',function(obj){
+                sync = obj['sync_config'];
+                onSyncRead();
+            });
+            
             function update(object) {
+                console.log(object);
                 if (object.hasOwnProperty(key)) {
                     found = object[key];
                 } else {
@@ -752,19 +758,21 @@ YUI.add('bookie-model', function (Y) {
                 } else {
                     ret = found;
                 }
+                console.log(key + " " + ret);
                 that.set(key, ret);
             }
 
-            if (sync && (key === 'api_key' || key === 'api_username' || key === 'api_url' || key === 'cache_content')) {
-                chrome.storage.sync.get(key, function(object) {
-                    update(object);
-                });
-            } else {
-                chrome.storage.local.get(key, function(object) {
-                    update(object);
-                });
+            function onSyncRead(){
+                if (sync && (key === 'api_key' || key === 'api_username' || key === 'api_url' || key === 'cache_content')) {
+                    chrome.storage.sync.get(key, function(object) {
+                        update(object);
+                    });
+                } else {
+                    chrome.storage.local.get(key, function(object) {
+                        update(object);
+                    });
+                }
             }
-
             //found = localStorage.getItem(key);
         },
 

--- a/bookie/static/js/bookie/model.js
+++ b/bookie/static/js/bookie/model.js
@@ -746,7 +746,6 @@ YUI.add('bookie-model', function (Y) {
             });
             
             function update(object) {
-                console.log(object);
                 if (object.hasOwnProperty(key)) {
                     found = object[key];
                 } else {
@@ -758,7 +757,6 @@ YUI.add('bookie-model', function (Y) {
                 } else {
                     ret = found;
                 }
-                console.log(key + " " + ret);
                 that.set(key, ret);
             }
 

--- a/bookie/static/js/bookie/view.js
+++ b/bookie/static/js/bookie/view.js
@@ -1965,15 +1965,15 @@ YUI.add('bookie-view', function (Y) {
             api.call({
                 'success': function (data, request) {
                     Y.Array.each(data.hash_list, function (h) {
-                        // write out each hash to localStorage
-                        // url hashes are stored locally
-                        // bookmarks are anyways stored in the server
-                        // only config is synced across extension instances
+                        // Write out each hash to chrome.storage
+                        // URL hashes are stored locally while the 
+                        // bookmarks are anyways stored in the server.
+                        // Only the config ["api_url","api_username","api_key","cache_content"] 
+                        // is synced across extension instances
 
-                        // localStorage.setItem(h, 'true');
-                        chrome.storage.local.set({
-                            h: true
-                        });
+                        var obj = {};
+                        obj[h] = true;
+                        chrome.storage.local.set(obj);
                     });
 
                     // finally stop the indicator from spinny spinny

--- a/bookie/static/js/bookie/view.js
+++ b/bookie/static/js/bookie/view.js
@@ -1874,17 +1874,28 @@ YUI.add('bookie-view', function (Y) {
          *
          */
         _init_form: function () {
+        
+            // this model is populated by options.js at the beginning
+            // options.js invokes load() to read from chrome.storage
+
             var opts = this.get('model');
 
             Y.one('#api_url').set('value', opts.get('api_url'));
             Y.one('#api_username').set('value', opts.get('api_username'));
             Y.one('#api_key').set('value', opts.get('api_key'));
 
-            if (opts.get('cache_content') === 'true') {
+            if (opts.get('cache_content')) {
                 Y.one('#cache_content').set('checked', true);
             } else {
                 Y.one('#cache_content').set('checked', false);
             }
+
+            if (opts.get('sync_config')) {
+                Y.one('#sync_config').set('checked', true);
+            } else {
+                Y.one('#sync_config').set('checked', false);
+            }
+            
         },
 
         /**
@@ -1955,7 +1966,14 @@ YUI.add('bookie-view', function (Y) {
                 'success': function (data, request) {
                     Y.Array.each(data.hash_list, function (h) {
                         // write out each hash to localStorage
-                        localStorage.setItem(h, 'true');
+                        // url hashes are stored locally
+                        // bookmarks are anyways stored in the server
+                        // only config is synced across extension instances
+
+                        // localStorage.setItem(h, 'true');
+                        chrome.storage.local.set({
+                            h: true
+                        });
                     });
 
                     // finally stop the indicator from spinny spinny
@@ -2033,9 +2051,15 @@ YUI.add('bookie-view', function (Y) {
                         opts.set('api_key', Y.one('#api_key').get('value'));
 
                         if (Y.one('#cache_content').get('checked')) {
-                            opts.set('cache_content', 'true');
+                            opts.set('cache_content', true);
                         } else {
-                            opts.set('cache_content', 'false');
+                            opts.set('cache_content', false);
+                        }
+
+                        if (Y.one('#sync_config').get('checked')) {
+                            opts.set('sync_config', true);
+                        } else {
+                            opts.set('sync_config', false);
                         }
 
                         // one updated, now save it

--- a/bookie/static/js/bookie/view.js
+++ b/bookie/static/js/bookie/view.js
@@ -2062,6 +2062,13 @@ YUI.add('bookie-view', function (Y) {
                             opts.set('sync_config', false);
                         }
 
+                        // set the flag so that it doesn't bug you everytime
+                        // for the configuration
+                        
+                        chrome.storage.local.set({
+                            "optionsConfigured": true
+                        });
+
                         // one updated, now save it
                         opts.save();
                         that._show_message('Saved your settings...', true);

--- a/bookie/static/js/bookie/view.js
+++ b/bookie/static/js/bookie/view.js
@@ -2062,13 +2062,6 @@ YUI.add('bookie-view', function (Y) {
                             opts.set('sync_config', false);
                         }
 
-                        // set the flag so that it doesn't bug you everytime
-                        // for the configuration
-                        
-                        chrome.storage.local.set({
-                            "optionsConfigured": true
-                        });
-
                         // one updated, now save it
                         opts.save();
                         that._show_message('Saved your settings...', true);

--- a/bookie/static/js/bookie/view.js
+++ b/bookie/static/js/bookie/view.js
@@ -1875,9 +1875,8 @@ YUI.add('bookie-view', function (Y) {
          */
         _init_form: function () {
         
-            // this model is populated by options.js at the beginning
+            // This model is populated by options.js at the beginning
             // options.js invokes load() to read from chrome.storage
-
             var opts = this.get('model');
 
             Y.one('#api_url').set('value', opts.get('api_url'));
@@ -1895,7 +1894,6 @@ YUI.add('bookie-view', function (Y) {
             } else {
                 Y.one('#sync_config').set('checked', false);
             }
-            
         },
 
         /**
@@ -1969,7 +1967,7 @@ YUI.add('bookie-view', function (Y) {
                         // URL hashes are stored locally while the 
                         // bookmarks are anyways stored in the server.
                         // Only the config ["api_url","api_username","api_key","cache_content"] 
-                        // is synced across extension instances
+                        // is synced across extension instances.
 
                         var obj = {};
                         obj[h] = true;

--- a/extensions/chrome_ext/background.html
+++ b/extensions/chrome_ext/background.html
@@ -1,16 +1,16 @@
 <!DOCTYPE HTML>
 <html lang="en">
 <head>
-	<meta charset="UTF-8">
-	<title></title>
-    <script src="combo.js"></script>
-    <script src="config.js"></script>
-    <script src="lib/api.js"></script>
-    <script src="lib/hash.js"></script>
-    <script src="lib/indicator.js"></script>
-    <script src="lib/model.js"></script>
-    <script src="lib/tagcontrol.js"></script>
-    <script src="lib/view.js"></script>
+    <meta charset="UTF-8">
+    <title></title>
+    <script type="text/javascript" src="combo.js"></script>
+    <script type="text/javascript" src="config.js"></script>
+    <script type="text/javascript" src="lib/api.js"></script>
+    <script type="text/javascript" src="lib/hash.js"></script>
+    <script type="text/javascript" src="lib/indicator.js"></script>
+    <script type="text/javascript" src="lib/model.js"></script>
+    <script type="text/javascript" src="lib/tagcontrol.js"></script>
+    <script type="text/javascript" src="lib/view.js"></script>
     <script type="text/javascript" src="chrome.js"></script>
 
 </head>

--- a/extensions/chrome_ext/chrome.js
+++ b/extensions/chrome_ext/chrome.js
@@ -524,6 +524,23 @@ YUI().add('bookie-chrome', function (Y) {
         init_background: function () {
             var that = this;
 
+            // Keep checking until the user configures a working
+            // combination for the first time.
+        
+            chrome.storage.local.get("optionsConfigured", function(obj) {
+                if (!obj["optionsConfigured"]) {
+                    chrome.tabs.create({
+                        url: "options.html"
+                    });
+                    var n = new Y.bookie.chrome.Notification({
+                        code: '9999',
+                        type: 'error',
+                        title: 'Err',
+                        message: 'To start using the extension, fill in the api_key, api_username and the api_url'
+                    });
+                }
+            });
+            
             // bind to the events to check if the current url is bookmarked or not
             chrome.tabs.onUpdated.addListener(
                 function(tabId, changeInfo, tab) {

--- a/extensions/chrome_ext/chrome.js
+++ b/extensions/chrome_ext/chrome.js
@@ -60,8 +60,6 @@ YUI().add('bookie-chrome', function (Y) {
 
             model.remove(function () {
                 chrome.storage.local.remove(hashid);
-                
-                //localStorage.removeItem(hashid);
                 window.close();
             });
         },
@@ -374,7 +372,7 @@ YUI().add('bookie-chrome', function (Y) {
                             n.cancel();
                         }, 5000);
                     } else {
-                        // Some post notify checks
+                        // Some post notify checks.
                         if (this.get('description') === "saved") {
                             chrome.tabs.getSelected(null, function (tab) {
                                 // We need to hash this into storage.

--- a/extensions/chrome_ext/chrome.js
+++ b/extensions/chrome_ext/chrome.js
@@ -116,8 +116,9 @@ YUI().add('bookie-chrome', function (Y) {
                 // chrome.storage / localStorage max size limit is 5MB
 
                 if (data.bmark.hash_id) {
+                    var hash = data.bmark.hash_id;
                     chrome.storage.local.set({
-                        {data.bmark.hash_id: true}
+                        hash: true
                     });
 
                     //localStorage.setItem(data.bmark.hash_id, 'true');
@@ -384,7 +385,7 @@ YUI().add('bookie-chrome', function (Y) {
                                 var hash_id = Y.bookie.Hash.hash_url(tab.url);
 
                                 chrome.storage.local.set({
-                                    hash_id: true;
+                                    hash_id: true
                                 });
 
                                 //localStorage.setItem(hash_id, 'true');

--- a/extensions/chrome_ext/chrome.js
+++ b/extensions/chrome_ext/chrome.js
@@ -118,11 +118,7 @@ YUI().add('bookie-chrome', function (Y) {
                 if (data.bmark.hash_id) {
                     var hash = data.bmark.hash_id;
                     chrome.storage.local.set({
-<<<<<<< HEAD
-                        data.bmark.hash_id: true
-=======
                         hash: true
->>>>>>> edfa42db8ae4549c502812e53c50c7b70218a365
                     });
 
                     //localStorage.setItem(data.bmark.hash_id, 'true');

--- a/extensions/chrome_ext/chrome.js
+++ b/extensions/chrome_ext/chrome.js
@@ -359,18 +359,23 @@ YUI().add('bookie-chrome', function (Y) {
             initializer: function (cfg) {
                 if (window.chrome !== undefined && chrome.tabs) {
                     if(this.get('type') === "error") {
-                        //show a desktop notification
-                        var n = webkitNotifications.createNotification(
-                            'logo.128.png',
-                            this.get('title'),
-                            this.get('message')
-                            );
-                        n.show();
 
-                        //hide the desktop notification after 5 seconds
-                        window.setTimeout(function() {
-                            n.cancel();
-                        }, 5000);
+                        //Show a desktop notification.
+                        var notifId,
+                            notifOptions = {
+                                type: 'basic',
+                                message: this.get('message'),
+                                title: this.get('title'),
+                                iconUrl: 'logo.128.png'
+                            };
+
+                        chrome.notifications.create("", notifOptions, function(notificationId) {
+                            notifId = notificationId;
+
+                            window.setTimeout(function() {
+                                chrome.notifications.clear(notifId, function(cleared) {});
+                            }, 5000);
+                        });
                     } else {
                         // Some post notify checks.
                         if (this.get('description') === "saved") {

--- a/extensions/chrome_ext/chrome.js
+++ b/extensions/chrome_ext/chrome.js
@@ -119,15 +119,13 @@ YUI().add('bookie-chrome', function (Y) {
                     var hash = data.bmark.hash_id;
                     chrome.storage.local.set({
                         hash: true
+                    }, function() {
+                        // update the badge now that we've saved
+                        var b = new Y.bookie.chrome.Badge();
+                        b.success();
+                        window.close();
                     });
-
-                    //localStorage.setItem(data.bmark.hash_id, 'true');
                 }
-
-                // update the badge now that we've saved
-                var b = new Y.bookie.chrome.Badge();
-                b.success();
-                window.close();
             });
         },
 
@@ -382,13 +380,11 @@ YUI().add('bookie-chrome', function (Y) {
                         if (this.get('description') === "saved") {
                             chrome.tabs.getSelected(null, function (tab) {
                                 // we need to hash this into storage
-                                var hash_id = Y.bookie.Hash.hash_url(tab.url);
-
+                                var hash = Y.bookie.Hash.hash_url(tab.url);
+                                
                                 chrome.storage.local.set({
-                                    hash_id: true
+                                    hash: true
                                 });
-
-                                //localStorage.setItem(hash_id, 'true');
                             });
                             window.close();
                         }
@@ -469,7 +465,7 @@ YUI().add('bookie-chrome', function (Y) {
          */
         is_bookmarked: function () {
             this._set_badge('+', this._colors.blue);
-        },
+        },  
 
         show_error: function () {
             this._set_badge('Err', this._colors.red, this.get('time'));
@@ -497,22 +493,20 @@ YUI().add('bookie-chrome', function (Y) {
     ns.BackgroundPage = Y.Base.create('bookie-chrome-background', Y.Base, [], {
         _check_url_bookmarked: function (url) {
             var is_bookmarked,
-                urlHash = Y.bookie.Hash.hash_url(url);
+                urlHash = Y.bookie.Hash.hash_url(url),
+                that = this;
             
-            //localStorage.getItem(Y.bookie.Hash.hash_url(url));
-            
-            chrome.storage.local.get(urlHash, function(object){
+            chrome.storage.local.get(urlHash, function(object) {
                 is_bookmarked = object.urlHash;
+                
+                // check if we have this bookmarked
+                // if so update the badge text with +
+                if (is_bookmarked) {
+                    that.badge.is_bookmarked();
+                } else {
+                    that.badge.clear();
+                }
             });
-
-            // check if we have this bookmarked
-            // if so update the badge text with +
-
-            if (is_bookmarked === 'true') {
-                this.badge.is_bookmarked();
-            } else {
-                this.badge.clear();
-            }
         },
 
         initializer: function (cfg) {

--- a/extensions/chrome_ext/chrome.js
+++ b/extensions/chrome_ext/chrome.js
@@ -515,23 +515,6 @@ YUI().add('bookie-chrome', function (Y) {
         init_background: function () {
             var that = this;
 
-            // Keep checking until the user configures a working
-            // combination for the first time.
-        
-            chrome.storage.local.get("optionsConfigured", function(obj) {
-                if (!obj["optionsConfigured"]) {
-                    chrome.tabs.create({
-                        url: "options.html"
-                    });
-                    var n = new Y.bookie.chrome.Notification({
-                        code: '9999',
-                        type: 'error',
-                        title: 'Err',
-                        message: 'To start using the extension, fill in the api_key, api_username and the api_url'
-                    });
-                }
-            });
-            
             // bind to the events to check if the current url is bookmarked or not
             chrome.tabs.onUpdated.addListener(
                 function(tabId, changeInfo, tab) {

--- a/extensions/chrome_ext/chrome.js
+++ b/extensions/chrome_ext/chrome.js
@@ -116,8 +116,9 @@ YUI().add('bookie-chrome', function (Y) {
                 // chrome.storage / localStorage max size limit is 5MB
 
                 if (data.bmark.hash_id) {
+                    var hash = data.bmark.hash_id;
                     chrome.storage.local.set({
-                        {data.bmark.hash_id: true}
+                        data.bmark.hash_id: true
                     });
 
                     //localStorage.setItem(data.bmark.hash_id, 'true');
@@ -384,7 +385,7 @@ YUI().add('bookie-chrome', function (Y) {
                                 var hash_id = Y.bookie.Hash.hash_url(tab.url);
 
                                 chrome.storage.local.set({
-                                    hash_id: true;
+                                    hash_id: true
                                 });
 
                                 //localStorage.setItem(hash_id, 'true');

--- a/extensions/chrome_ext/chrome.js
+++ b/extensions/chrome_ext/chrome.js
@@ -108,24 +108,22 @@ YUI().add('bookie-chrome', function (Y) {
             // should just be able to fire the save method on the model and
             // display to the user we're working on it.
             model.save(function (data, request) {
-                // make sure that we store that this is a saved bookmark in
-                // the localStorage index 
-                // instead of localStorage, use chromeStorage to avoid unnecessary
+                // Use chrome.storage.local to save the bookmark. 
+                // Use chrome.storage to avoid unnecessary
                 // boolean to string and string to boolean conversions. 
-                // you can save only so much info
-                // chrome.storage / localStorage max size limit is 5MB
+                // You can save only so much info in chrome.storage/localStorage.
+                // Max size limitation for an app is 5MB
 
                 if (data.bmark.hash_id) {
-                    var hash = data.bmark.hash_id;
-                    chrome.storage.local.set({
-                        hash: true
-                    }, function() {
-                        // update the badge now that we've saved
-                        var b = new Y.bookie.chrome.Badge();
-                        b.success();
-                        window.close();
-                    });
+                    var obj = {};
+                    obj[data.bmark.hash_id] = true;
+                    chrome.storage.local.set(obj);
                 }
+
+                // Update the badge now that we've saved.
+                var b = new Y.bookie.chrome.Badge();
+                b.success();
+                window.close();
             });
         },
 
@@ -376,15 +374,14 @@ YUI().add('bookie-chrome', function (Y) {
                             n.cancel();
                         }, 5000);
                     } else {
-                        // some post notify checks
+                        // Some post notify checks
                         if (this.get('description') === "saved") {
                             chrome.tabs.getSelected(null, function (tab) {
-                                // we need to hash this into storage
+                                // We need to hash this into storage.
                                 var hash = Y.bookie.Hash.hash_url(tab.url);
-                                
-                                chrome.storage.local.set({
-                                    hash: true
-                                });
+                                var obj = {};
+                                obj[hash] = true;
+                                chrome.storage.local.set(obj);
                             });
                             window.close();
                         }

--- a/extensions/chrome_ext/manifest.json
+++ b/extensions/chrome_ext/manifest.json
@@ -1,38 +1,37 @@
 {
     "background": {
         "page": "background.html"
-    }, 
+    },
     "browser_action": {
-        "default_icon": "logo.24.png", 
-        "default_popup": "popup.html", 
+        "default_icon": "logo.24.png",
+        "default_popup": "popup.html",
         "default_title": "Post Bookie Bookmark"
-    }, 
-    "content_scripts": [
-        {
-            "js": [
-                "shortcut.js"
-            ], 
-            "matches": [
-                "http://*/*", 
-                "https://*/*"
-            ]
-        }
-    ], 
-    "description": "Bookie Bookmarks", 
+    },
+    "content_scripts": [{
+        "js": [
+            "shortcut.js"
+        ],
+        "matches": [
+            "http://*/*",
+            "https://*/*"
+        ]
+    }],
+    "description": "Bookie Bookmarks",
     "icons": {
-        "128": "logo.128.png", 
-        "16": "logo.16.png", 
+        "128": "logo.128.png",
+        "16": "logo.16.png",
         "24": "logo.24.png"
-    }, 
-    "manifest_version": 2, 
-    "name": "Bookie", 
-    "options_page": "options.html", 
+    },
+    "manifest_version": 2,
+    "name": "Bookie",
+    "options_page": "options.html",
     "permissions": [
-        "tabs", 
-        "notifications", 
-        "contextMenus", 
-        "https://*/*", 
-        "http://*/*"
-    ], 
+        "tabs",
+        "notifications",
+        "contextMenus",
+        "https://*/*",
+        "http://*/*",
+        "storage"
+    ],
     "version": "0.4.12"
 }

--- a/extensions/chrome_ext/manifest.json
+++ b/extensions/chrome_ext/manifest.json
@@ -7,15 +7,17 @@
         "default_popup": "popup.html",
         "default_title": "Post Bookie Bookmark"
     },
-    "content_scripts": [{
-        "js": [
-            "shortcut.js"
-        ],
-        "matches": [
-            "http://*/*",
-            "https://*/*"
-        ]
-    }],
+    "content_scripts": [
+        {
+            "js": [
+                "shortcut.js"
+            ],
+            "matches": [
+                "http://*/*",
+                "https://*/*"
+            ]
+        }
+    ],
     "description": "Bookie Bookmarks",
     "icons": {
         "128": "logo.128.png",
@@ -26,12 +28,12 @@
     "name": "Bookie",
     "options_page": "options.html",
     "permissions": [
-        "tabs",
-        "notifications",
         "contextMenus",
         "https://*/*",
         "http://*/*",
-        "storage"
+        "notifications",
+        "storage",
+        "tabs"
     ],
     "version": "0.4.12"
 }

--- a/extensions/chrome_ext/options.html
+++ b/extensions/chrome_ext/options.html
@@ -66,7 +66,7 @@
                     </li>
                     <li>
                         <label for="api_key">API key</label>
-                        <input type="password" placeholder="api key" id="api_key"/>
+                        <input type="text" placeholder="api key" id="api_key"/>
                     </li>
                     <li>
                         <label for="cache_content">Cache Content</label>

--- a/extensions/chrome_ext/options.html
+++ b/extensions/chrome_ext/options.html
@@ -72,6 +72,10 @@
                         <label for="cache_content">Cache Content</label>
                         <input type="checkbox" id="cache_content" />
                     </li>
+                    <li>
+                        <label for="sync_config">Sync current configuration</label>
+                        <input type="checkbox" id="sync_config" />
+                    </li>
                 </ul>
                 <div id="buttonrow">
                     <button id="saveBtn" type="submit" class="button">Save</button>

--- a/extensions/chrome_ext/options.js
+++ b/extensions/chrome_ext/options.js
@@ -1,8 +1,10 @@
-YUI().use('bookie-model', 'bookie-view', function (Y) {
+YUI().use('bookie-model', 'bookie-view', function(Y) {
     var options = new Y.bookie.OptionsModel();
     options.load();
-    var view = new Y.bookie.OptionsView({
-        model: options
-    });
-    view.render();
+    setTimeout(function() {
+        var view = new Y.bookie.OptionsView({
+            model: options
+        });
+        view.render();
+    }, 500);
 });

--- a/extensions/chrome_ext/options.js
+++ b/extensions/chrome_ext/options.js
@@ -1,10 +1,10 @@
 YUI().use('bookie-model', 'bookie-view', function(Y) {
     var options = new Y.bookie.OptionsModel();
-    options.load();
-    setTimeout(function() {
+    options.load(onOptionsLoad);
+    function onOptionsLoad() {
         var view = new Y.bookie.OptionsView({
             model: options
         });
         view.render();
-    }, 500);
+    }
 });

--- a/extensions/chrome_ext/popup.js
+++ b/extensions/chrome_ext/popup.js
@@ -5,41 +5,43 @@ YUI().use('bookie-chrome', function (Y) {
         if (tab_data) {
             var settings = new Y.bookie.OptionsModel();
             // load the settings from the extension for use
-            settings.load();
+            settings.load(onSettingsLoad);
 
             // don't worry about loading the content of the page if we
             // don't have it set in our options
-            if (settings.get('cache_content') !== 'true') {
-                // then skip it, we don't want the added load on the
-                // browser or the server
-            } else {
-                chrome.extension.onRequest.addListener(
-                    function(request, sender, sendResponse) {
-                        if (request.id === 'from_readable') {
-                            Y.one('#content').set('value', request.html);
+
+            function onSettingsLoad(){
+                if (settings.get('cache_content') !== 'true') {
+                    // then skip it, we don't want the added load on the
+                    // browser or the server
+                } else {
+                    chrome.extension.onRequest.addListener(
+                        function(request, sender, sendResponse) {
+                            if (request.id === 'from_readable') {
+                                Y.one('#content').set('value', request.html);
+                            }
                         }
-                    }
-                );
+                    );
 
-                var bkg = chrome.extension.getBackgroundPage();
-                bkg.inject_readable(function () {
-                    var c = document.getElementById('content');
-                    c.value = bkg.get_html_content();
-                });
-            }
-
-            var bookmark = new Y.bookie.Bmark(Y.merge(
-                tab_data, {
-                    api_cfg: settings.get_apicfg()
+                    var bkg = chrome.extension.getBackgroundPage();
+                    bkg.inject_readable(function() {
+                        var c = document.getElementById('content');
+                        c.value = bkg.get_html_content();
+                    });
                 }
-            ));
 
-            var c = new Y.bookie.chrome.Popup({
-                settings: settings,
-                model: bookmark
-            });
-            c.render();
+                var bookmark = new Y.bookie.Bmark(Y.merge(
+                    tab_data, {
+                        api_cfg: settings.get_apicfg()
+                    }
+                ));
 
+                var c = new Y.bookie.chrome.Popup({
+                    settings: settings,
+                    model: bookmark
+                });
+                c.render();
+            }
         } else {
             var n = new Y.bookie.chrome.Notification({
                 code: '9999',


### PR DESCRIPTION
In order to sync the user credentials like (api_key, api_username, api_url, cache_content) we need to use the chrome.storage.sync feature instead of local storage.

Also, with chrome.storage.local/sync boolean variables can be stored as is without converting them to strings and thus eliminating the need to convert them back to booleans. 

Following commit implements the same and fixes some typos in the documentation along with some fresh documentation. 

Addresses modified #249 as per discussion.
