### PR TITLE
Notify user that a duplicate tag has been entered

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,6 +69,7 @@ sysdeps:
 		else \
 			sudo pacman -S $(SYSDEPS_ARCH); \
 		fi \
+		sudo systemctl start redis
 	elif which yum &> /dev/null; then \
 		if [ $(NONINTERACTIVE) ]; then \
 			sudo yum install -y $(SYSDEPS_FEDORA); \

--- a/Makefile
+++ b/Makefile
@@ -211,6 +211,9 @@ test_rsswatch:
 .PHONY: test_tagcontrol
 test_tagcontrol:
 	xdg-open $(JSTESTURL)/test_tagcontrol.html
+.PHONY: test_userstats
+test_userstats:
+	xdg-open $(JSTESTURL)/test_user_stats.html
 .PHONY: test_view
 test_view:
 	xdg-open $(JSTESTURL)/test_view.html

--- a/bookie/models/stats.py
+++ b/bookie/models/stats.py
@@ -106,9 +106,11 @@ class StatBookmarkMgr(object):
     def count_user_bookmarks(username):
         """Count the total number of bookmarks for the user in the system"""
         total = BmarkMgr.count(username)
+        tstamp = datetime.utcnow()
         stat = StatBookmark(
             attrib=USER_CT.format(username),
-            data=total
+            data=total,
+            tstamp=datetime(tstamp.year, tstamp.month, tstamp.day)
         )
         DBSession.add(stat)
 
@@ -126,10 +128,7 @@ class StatBookmarkMgr(object):
                 # If both start_date and end_date are None,
                 # end_date will be the current date
                 end_date = datetime.utcnow()
-                end_date = datetime(
-                    end_date.year,
-                    end_date.month,
-                    end_date.day)
+
             # Otherwise if there's no start_date but we have an end_date,
             # assume that the user wants the STATS_WINDOW worth of stats.
             start_date = end_date - timedelta(days=STATS_WINDOW)

--- a/bookie/models/stats.py
+++ b/bookie/models/stats.py
@@ -106,11 +106,9 @@ class StatBookmarkMgr(object):
     def count_user_bookmarks(username):
         """Count the total number of bookmarks for the user in the system"""
         total = BmarkMgr.count(username)
-        tstamp = datetime.utcnow()
         stat = StatBookmark(
             attrib=USER_CT.format(username),
-            data=total,
-            tstamp=datetime(tstamp.year, tstamp.month, tstamp.day)
+            data=total
         )
         DBSession.add(stat)
 

--- a/bookie/static/js/bookie/view.js
+++ b/bookie/static/js/bookie/view.js
@@ -1005,6 +1005,8 @@ YUI.add('bookie-view', function (Y) {
             this.api = new Y.bookie.Api.route.UserBmarkCount(this.api_cfg);
             this.api.call({
                 success: function(data, request) {
+                    Y.one('#userstats_msg').setContent('');
+                    Y.one('#userstats_msg').hide();
                     // Stores the data for the graph.
                     var myDataValues = [];
                     data.count.forEach(function(value) {
@@ -1023,6 +1025,8 @@ YUI.add('bookie-view', function (Y) {
                     });
 		},
                 error: function (data, status_str, response, args) {
+                    Y.one('#userstats_msg').show();
+                    Y.one('#userstats_msg').setContent('Error fetching the bookmark count');
                 }
             });
 	},

--- a/bookie/static/js/tests/test_api.js
+++ b/bookie/static/js/tests/test_api.js
@@ -17,7 +17,7 @@ YUI.add('bookie-test-api', function (Y) {
 
         testApiExists: function () {
             Y.Assert.isObject(Y.bookie.Api,
-                              "Should find an objcet for Api module");
+                              "Should find an object for Api module");
         },
 
         testPublicBmarkList: function () {
@@ -380,6 +380,33 @@ YUI.add('bookie-test-api', function (Y) {
                     email: 'testing@me.com'
                 },
                 api = new Y.bookie.Api.route.Invite(API_CFG);
+
+            Y.io = gen_fakeio(test_func);
+            api.call({});
+            Y.Assert.isTrue(hit);
+        },
+
+        testUserBmarkCount: function() {
+            var that = this,
+                hit = false,
+                test_func = function(url, cfg) {
+                    Y.Assert.areEqual('POST', cfg.method);
+                    Y.Assert.areEqual(
+                        'http://127.0.0.1:6543/api/v1/admin/stats/bmarkcount',
+                        url);
+                    Y.Assert.areEqual(
+                        Y.JSON.stringify({
+                        api_key: '2dcf75460cb5',
+                        username: 'admin'
+                    }), cfg.data);
+                    hit = true;
+            },
+            API_CFG = {
+                url: 'http://127.0.0.1:6543/api/v1',
+                username: 'admin',
+                api_key: '2dcf75460cb5'
+	    },
+            api = new Y.bookie.Api.route.UserBmarkCount(API_CFG);
 
             Y.io = gen_fakeio(test_func);
             api.call({});

--- a/bookie/static/js/tests/test_history.js
+++ b/bookie/static/js/tests/test_history.js
@@ -8,7 +8,7 @@ YUI.add('bookie-test-history', function (Y) {
 
         testHistoryExists: function () {
             Y.Assert.isObject(Y.bookie.BmarkListHistory,
-                              "Should find an objcet for History module");
+                              "Should find an object for History module");
         }
     }));
 }, '0.4', {

--- a/bookie/static/js/tests/test_model.js
+++ b/bookie/static/js/tests/test_model.js
@@ -46,7 +46,7 @@ YUI.add('bookie-test-model', function (Y) {
         "Bmark model should exist": function () {
             A.isObject(
                 Y.bookie.Bmark,
-                "Should find an objcet for Bmark model"
+                "Should find an object for Bmark model"
             );
         },
 

--- a/bookie/static/js/tests/test_readable.js
+++ b/bookie/static/js/tests/test_readable.js
@@ -20,7 +20,7 @@ YUI.add('bookie-test-readable', function (Y) {
 
         testModuleExists: function () {
             Y.Assert.isObject(Y.bookie.readable.Api,
-                "Should find an objcet for readable api module");
+                "Should find an object for readable api module");
         },
 
         testInitCorrect: function () {

--- a/bookie/static/js/tests/test_user_stats.html
+++ b/bookie/static/js/tests/test_user_stats.html
@@ -1,0 +1,32 @@
+<html>
+<head>
+    <meta http-equiv="content-type" content="text/html; charset=utf-8">
+    <script src="../build/y/yui/yui.js"></script>
+    <script src="../bookie/api.js"></script>
+    <script src="../bookie/view.js"></script>
+    <script src="test_user_stats.js"></script>
+    <title>User Stats Tests</title>
+</head>
+<body class="yui3-skin-sam">
+    <div id="log"></div>
+    <div id="userstats_msg" class="error"></div>
+    <div id="calendar"></div>
+    <div id="bmark_count_graph" style="margin-left: auto; margin-right: auto; width: 1000px; height: 500px;"></div>
+    <script type="text/javascript">
+        YUI().use('calendar', 'charts', 'datatype-date', 'test-console', 'bookie-test-userstats', function (Y) {
+            // RUN ALL THE TESTS!!!!!
+            var yconsole = new Y.Test.Console({
+                filters: {
+                    pass: true,
+                    fail: true
+                },
+                newestOnTop: false
+            });
+            yconsole.render('#log');
+
+            Y.Test.Runner.add(Y.bookie.test.userstats.suite);
+            Y.Test.Runner.run();
+        });
+    </script>
+</body>
+</html>

--- a/bookie/static/js/tests/test_user_stats.js
+++ b/bookie/static/js/tests/test_user_stats.js
@@ -1,0 +1,79 @@
+// Create a new YUI instance and populate it with the required modules.
+YUI.add('bookie-test-userstats', function (Y) {
+    var ns = Y.namespace('bookie.test.userstats');
+    ns.suite = new Y.Test.Suite('User Stats Tests');
+
+    ns.suite.add(new Y.Test.Case({
+        name: "User Stats Tests",
+
+        setUp: function() {
+        },
+
+        tearDown: function() {
+        },
+
+        testApiExists: function() {
+            Y.Assert.isObject(Y.bookie.Api,
+                              "Should find an object for Api module");
+        },
+
+        test_error: function() {
+            // Stub out the API call with a fake response.
+            var old_method = Y.bookie.Api.route.UserBmarkCount;
+            Y.bookie.Api.route.UserBmarkCount = function(cfg) {
+                return {
+                    call: function(cfg) {
+                        cfg.error();
+                    }
+                };
+            };
+            var user_stats_error = new Y.bookie.UserBmarkCountView();
+            user_stats_error.render();
+            // The error message should be shown to the user.
+            this.wait(function() {
+                var error_msg = Y.one('#userstats_msg');
+                Y.Assert.areEqual('Error fetching the bookmark count', error_msg.getContent());
+                Y.bookie.Api.route.UserBmarkCount = old_method;
+            }, 500);
+        },
+
+        test_success: function() {
+            // Fake bookmark count response.
+            var resp = [
+            {
+                "tstamp": "2014-03-04 00:00:00",
+                "data": 20},
+            {
+                "tstamp": "2014-03-05 00:00:00",
+                "data": 25},
+            {
+                "tstamp": "2014-03-06 00:00:00",
+                "data": 22}
+            ];
+            // Stub out the API call with a fake response.
+            var old_method = Y.bookie.Api.route.UserBmarkCount;
+            Y.bookie.Api.route.UserBmarkCount = function(cfg) {
+                return {
+                    call: function(cfg) {
+                        cfg.success({
+                            count: resp
+                        });
+                    }
+                };
+            };
+            var user_stats_success = new Y.bookie.UserBmarkCountView();
+            user_stats_success.render();
+            // No error should be shown in case of a successful response.
+            this.wait(function() {
+                var success_msg = Y.one('#userstats_msg');
+                Y.Assert.areEqual('', success_msg.getContent());
+                Y.bookie.Api.route.UserBmarkCount = old_method;
+            }, 500);
+        }
+
+    }));
+}, '0.4', {
+    requires: [
+        'test', 'bookie-view'
+    ]
+});

--- a/bookie/static/js/tests/test_view.js
+++ b/bookie/static/js/tests/test_view.js
@@ -73,7 +73,7 @@ YUI.add('bookie-test-view', function (Y) {
 
         testViewExists: function () {
             Y.Assert.isObject(Y.bookie.BmarkView,
-                              "Should find an objcet for Bmark view");
+                              "Should find an object for Bmark view");
         },
 
         test_render_view: function () {
@@ -310,7 +310,7 @@ YUI.add('bookie-test-view', function (Y) {
             var login = new Y.bookie.LoginView();
             login.render();
 
-            // The error message should be shows to the user.
+            // The error message should be shown to the user.
             // simulate click on submit button
             Y.one('#submit_forgotten').simulate('click');
             this.wait(function() {

--- a/bookie/templates/stats/userstats.mako
+++ b/bookie/templates/stats/userstats.mako
@@ -9,6 +9,7 @@ ${account_nav()}
 <div class="yui3-g">
     <div class="yui3-u-1">
         <div class="form">
+            <div id="userstats_msg" class="error"></div>
             <div id="calendar"></div>
             <div id="bmark_count_graph"></div>
             <%def name="add_js()">

--- a/bookie/tests/factory.py
+++ b/bookie/tests/factory.py
@@ -85,6 +85,7 @@ def make_user_bookmark_count(username, data, tstamp=None):
     """Generate a fake user bookmark count for testing use"""
     if tstamp is None:
         tstamp = datetime.utcnow()
+        tstamp = datetime(tstamp.year, tstamp.month, tstamp.day)
     bmark_count = StatBookmark(tstamp=tstamp,
                                attrib=USER_CT.format(username),
                                data=data)

--- a/bookie/tests/factory.py
+++ b/bookie/tests/factory.py
@@ -85,7 +85,6 @@ def make_user_bookmark_count(username, data, tstamp=None):
     """Generate a fake user bookmark count for testing use"""
     if tstamp is None:
         tstamp = datetime.utcnow()
-        tstamp = datetime(tstamp.year, tstamp.month, tstamp.day)
     bmark_count = StatBookmark(tstamp=tstamp,
                                attrib=USER_CT.format(username),
                                data=data)

--- a/bookie/tests/test_api/test_base_api.py
+++ b/bookie/tests/test_api/test_base_api.py
@@ -712,7 +712,30 @@ class BookieAPITest(unittest.TestCase):
         self.assertTrue(ping['success'])
 
         self._check_cors_headers(res)
+ 
+    def test_api_ping_failed_invalid_api(self):
+        """If you don't supply a valid api key, you've failed the ping"""
+        
+        # Login a user and then test the validation of api key
+        
+        user_data = {'login': u'admin',
+                     'password': u'admin',
+                     'form.submitted': u'true'}
 
+        # Assuming user logged in without errors
+        login_res = self.testapp.post('/login',
+                                params=user_data)
+        
+        # Check for authentication of api key
+        
+        res = self.testapp.get('/api/v1/admin/ping?api_key=' + 'invalid',
+                               status=200)
+        ping = json.loads(res.body)
+
+        self.assertFalse(ping['success'])
+        self.assertEqual(ping['message'], "API key is invalid.")
+        self._check_cors_headers(res)
+        
     def test_api_ping_failed_nouser(self):
         """If you don't supply a username, you've failed the ping"""
         res = self.testapp.get('/api/v1/ping?api_key=' + API_KEY,

--- a/bookie/views/api.py
+++ b/bookie/views/api.py
@@ -51,7 +51,7 @@ def _api_response(request, data):
     # Wrap the data response with CORS headers for cross domain JS clients.
     request.response.headers.extend([
         ('Access-Control-Allow-Origin', '*'),
-        ('Access-Control-Allow-Headers', 'X-Requested-With, Content-Type')
+        ('Access-Control-Allow-Headers', 'X-Requested-With')
     ])
 
     return data

--- a/bookie/views/api.py
+++ b/bookie/views/api.py
@@ -63,10 +63,23 @@ def ping(request):
     """Verify that you've setup your api correctly and verified
 
     """
-    return _api_response(request, {
-        'success': True,
-        'message': 'Looks good'
-    })
+    rdict = request.matchdict
+    params = request.params
+    username = rdict.get('username', None)
+    api_key = params.get('api_key', None)
+    user = UserMgr.get(username=username)
+    
+    # Check if user provided the correct api_key
+    if api_key == user.api_key:
+        return _api_response(request, {
+            'success': True,
+            'message': 'Looks good'
+        })
+    else:
+        return _api_response(request, {
+            'success': False,
+            'message': 'API key is invalid.'
+        })   
 
 
 @view_config(route_name="api_ping_missing_user", renderer="jsonp")

--- a/bookie/views/api.py
+++ b/bookie/views/api.py
@@ -51,7 +51,7 @@ def _api_response(request, data):
     # Wrap the data response with CORS headers for cross domain JS clients.
     request.response.headers.extend([
         ('Access-Control-Allow-Origin', '*'),
-        ('Access-Control-Allow-Headers', 'X-Requested-With')
+        ('Access-Control-Allow-Headers', 'X-Requested-With, Content-Type')
     ])
 
     return data

--- a/scripts/js/jsmin_all.py
+++ b/scripts/js/jsmin_all.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 """Handle minifying all javascript files in the build directory by walking
 


### PR DESCRIPTION
Fixes #198. 

Fade out the original tag and retain the recently entered tag
