### PR TITLE
Weekly bookmark count with tests

### DIFF
--- a/bookie/models/stats.py
+++ b/bookie/models/stats.py
@@ -139,12 +139,20 @@ class StatBookmarkMgr(object):
                 end_date = start_date + timedelta(days=STATS_WINDOW)
         # Since we're comparing dates with 00:00:00 we need to add one day and
         # do <=.
-        return [
+        response = [
             StatBookmarkMgr.get_user_bmark_count(
                 username, start_date, end_date + timedelta(days=1)),
             start_date,
             end_date
         ]
+        if len(response[0]) > 31:
+            days = 0
+            data = []
+            while days < len(response[0]):
+                data.append(response[0][days])
+                days += 7
+            response[0] = data
+        return response
 
 
 class StatBookmark(Base):


### PR DESCRIPTION
For bookmark count, when time period > 31, a weekly bookmark count response is now returned. Tests also included.
