### PR TITLE
Fixes issue #363.

### DIFF
--- a/bookie/static/js/bookie/model.js
+++ b/bookie/static/js/bookie/model.js
@@ -484,9 +484,12 @@ YUI.add('bookie-model', function (Y) {
                  */
                 'stored': {
                     getter: function(val) {
-                      return val.replace(/-/g, '/') + " UTC";
+                        if (val) {
+                            return val.replace(/-/g, '/') + " UTC";
+                        } else {
+                            return "";
+                        }
                     }
-
                 },
 
                 'stored_date': {


### PR DESCRIPTION
Misses the safety check. When you are about to bookmark something for the first time, the request sent to the server contains the stored field by invoking model.get('stored'). Unfortunately, it does not account for the undefined state of the variable and performs operations on it, which results in an unexpected error.

The server replies back with a Bmark object containing the "stored" variable which is used in future communications.
