### PR TITLE
Setup Vagrant for easy non-Ubuntu dev env.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ parts
 .hg
 .bzr
 .svn
+.vagrant
 /include
 /bin
 /man

--- a/CREDITS.txt
+++ b/CREDITS.txt
@@ -26,3 +26,4 @@ Thanks to these people that have contributed code/assistance to bookie
 - Sambuddha Basu
 - Fernando César
 - Jelmer Vernooij
+- Kyle Adams

--- a/README.rst
+++ b/README.rst
@@ -26,10 +26,26 @@ If you're on Ubuntu, you should be able to get started with:
     $ git clone git://github.com/bookieio/Bookie.git
     $ cd Bookie && make sysdeps && make install && make run
     $ google-chrome (or other browser) http://127.0.0.1:6543
-    
+
+If you're on anything else, give our Vagrant image a try. If you don't have it already, you'll need to download and install Vagrant:
+
+http://www.vagrantup.com/downloads.html
+
+After that, you should be able to get started with:
+
+::
+
+    $ git clone git://github.com/bookieio/Bookie.git
+    $ cd Bookie
+    $ vagrant up
+    $ vagrant ssh
+    % cd /vagrant
+    % make run
+    $ google-chrome (or other browser) http://127.0.0.1:4567
+
 Note: If you run into problems during the `make sysdeps && make install` process, run `make clean_all` to reset the environment prior to re-running `make sysdeps && make install`.
 
-If you're unable to complete the install process and need additional help please feel freeo to contact us in the #bookie IRC channel on Freenode, or the mailing lists.
+If you're unable to complete the install process and need additional help please feel free to contact us in the #bookie IRC channel on Freenode, or the mailing lists.
 
 Developing
 -----------

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,14 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# Vagrantfile API/syntax version. Don't touch unless you know what you're doing!
+VAGRANTFILE_API_VERSION = "2"
+
+Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
+  config.vm.box = "hashicorp/precise64"
+  config.vm.provision :shell, :path => "bootstrap.sh"
+  config.vm.network :forwarded_port, host: 4567, guest: 6543
+  config.vm.provider "virtualbox" do |v|
+    v.name = "Bookie Vagrant"
+  end
+end

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env sh
+
+apt-get update
+apt-get install -y make
+
+cd /vagrant
+export NONINTERACTIVE=1
+make sysdeps && make install

--- a/scripts/admin/first_bookmark.py
+++ b/scripts/admin/first_bookmark.py
@@ -16,19 +16,23 @@ from bookie.models import initialize_sql
 if __name__ == "__main__":
     ini = ConfigParser()
     ini_path = path.join(path.dirname(path.dirname(path.dirname(__file__))),
-        'bookie.ini')
+                         'bookie.ini')
 
     ini.readfp(open(ini_path))
     initialize_sql(dict(ini.items("app:bookie")))
 
     from bookie.models import DBSession
-    from bookie.models import Bmark
+    from bookie.models import Bmark, BmarkMgr
+    url = u'http://bmark.us'
+    # make sure the bookmark isn't already there
+    if (BmarkMgr.get_by_url(url)):
+        return
 
-    bmark_us = Bmark(u'http://bmark.us',
+    bmark_us = Bmark(url,
                      u'admin',
                      desc=u'Bookie Website',
-                     ext= u'Bookie Documentation Home',
-                     tags = u'bookmarks')
+                     ext=u'Bookie Documentation Home',
+                     tags=u'bookmarks')
 
     bmark_us.stored = datetime.now()
     bmark_us.updated = datetime.now()


### PR DESCRIPTION
Per the updated `README.rst`, you can now get Bookie running on non-Ubuntu machines with:

```
$ vagrant up
$ vagrant ssh
% cd /vagrant && make run
```
