### PR TITLE
By default, bookmarks stored should be private

### DIFF
--- a/bookie/models/__init__.py
+++ b/bookie/models/__init__.py
@@ -502,7 +502,8 @@ class BmarkMgr(object):
         return res
 
     @staticmethod
-    def store(url, username, desc, ext, tags, dt=None, inserted_by=None):
+    def store(url, username, desc, ext, tags, dt=None, inserted_by=None,
+              is_private=True):
         """Store a bookmark
 
         :param url: bookmarked url
@@ -522,6 +523,7 @@ class BmarkMgr(object):
             desc=desc,
             ext=ext,
             tags=tags,
+            is_private=is_private,
         )
 
         mark.inserted_by = inserted_by

--- a/bookie/tests/test_models/test_privatebmark.py
+++ b/bookie/tests/test_models/test_privatebmark.py
@@ -2,7 +2,10 @@
 
 from pyramid import testing
 
-from bookie.models import Bmark
+from bookie.models import (
+    Bmark,
+    BmarkMgr,
+)
 from bookie.models.auth import User
 
 from bookie.tests import empty_db
@@ -60,6 +63,45 @@ class TestPrivateBmark(TestDBBase):
         bmark = Bmark(
             url=gen_random_word(12),
             username=user.username,
+            is_private=False
+        )
+        self.assertEqual(
+            False,
+            bmark.is_private)
+
+    def test_storing_private_true(self):
+        """Verify the value of is_private defaults to True"""
+        user = User()
+        user.username = gen_random_word(10)
+        bmark_url = u'http://bmark.us'
+        bmark_desc = u'This is a test bookmark'
+        bmark_ext = u'Some extended notes'
+        bmark_tags = u'python test'
+        bmark = BmarkMgr.store(
+            url=bmark_url,
+            username=user.username,
+            desc=bmark_desc,
+            ext=bmark_ext,
+            tags=bmark_tags
+        )
+        self.assertEqual(
+            True,
+            bmark.is_private)
+
+    def test_storing_private_false(self):
+        """Verify the value of is_private is False"""
+        user = User()
+        user.username = gen_random_word(10)
+        bmark_url = u'http://bmark.us'
+        bmark_desc = u'This is a test bookmark'
+        bmark_ext = u'Some extended notes'
+        bmark_tags = u'python test'
+        bmark = BmarkMgr.store(
+            url=bmark_url,
+            username=user.username,
+            desc=bmark_desc,
+            ext=bmark_ext,
+            tags=bmark_tags,
             is_private=False
         )
         self.assertEqual(


### PR DESCRIPTION
By default, the store function of BmarkMgr should be storing private bookmarks unless specified otherwise.
