### PR TITLE
Update dependencies.

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,6 +1,7 @@
 coverage
 flake8
 mock
+pyinotify==0.9.4
 -e hg+https://bitbucket.org/hpk42/pytest/#egg=pytest
 pytest-cov
 unittest2

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,11 +24,9 @@ MarkupSafe==0.12
 Paste==1.7.5.1
 PasteDeploy==1.5.0
 PasteScript==1.7.5
-psycopg2==2.4.6
 py==1.4.20
 py-bcrypt==0.3
 Pygments==1.4
-pyinotify==0.9.4
 pyramid==1.5
 pyramid_mako==1.0.1
 pyramid-celery==1.3


### PR DESCRIPTION
- Remove psycopg from the base install as it defaults to sqlite.
- Move the pyinotify to the dev-requirements so that OSX base install can
  work.
