### PR TITLE
Document sqlite -> mysql/postgresql migration and nltk_data environment variable in wsgi

### DIFF
--- a/docs/hosting.rst
+++ b/docs/hosting.rst
@@ -241,6 +241,8 @@ Then you need to create a pyramid.wsgi file in the root of your Bookie virtualen
 
 ::
 
+    import os
+    os.environ['NLTK_DATA'] = '/home/user/bookie/bookie/download-cache/nltk'
     from pyramid.paster import get_app
     application = get_app('/home/user/bookie/bookie/mybookie.ini', 'bookie')
 

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -122,6 +122,44 @@ the database for you. Once you're ready run:
 
     $ make db_up
 
+
+Migrate from SQLite to MySQL or Postgresql
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+First, follow the steps above to set up an empty MySQL/Postgresql database.
+
+To prepare for the migration, we first need to empty the `alembic_version`
+and `users` tables which are not fully empty. To do this in MySQL:
+
+::
+
+    TRUNCATE `alembic_version`;
+    DELETE FROM `users` WHERE 1;
+
+Then, install the migration tools:
+
+::
+
+    $ apt-get install ruby-sqlite3 ruby-mysql
+    - OR -
+    $ apt-get install ruby-sqlite3 ruby-pg
+
+    $ gem install rack -v 1.4.5
+    $ gem install taps
+
+Next, let's publish our existing sqlite database:
+
+::
+
+    $ taps server sqlite:///home/user/bookie/bookie/bookie.db tmpuser tmppass &
+
+And finally we pull the data into our new MySQL/Postgresql database:
+
+::
+
+   $ taps pull -s mysql://bookie:***@localhost/bookie http://tmpuser:tmppass@localhost:5000
+   - OR -
+   $ taps pull -s postgres://bookie:***@localhost/bookie http://tmpuser:tmppass@localhost:5000
+
 .. _`browser extension`: extensions.html
 .. _`hosting docs`: hosting.html
 .. _`Celery`: http://www.celeryproject.org/


### PR DESCRIPTION
I found it useful to pass the NLTK_DATA environment variable when hosting Bookie in wsgi, otherwise I would get a MissingCorpusException. Other than the NLTK_DATA envvar, the library seems to look for the nltk data only in a handful of hardcoded paths.
