### PR TITLE
Add support for finding/fixing missing fulltext

### DIFF
--- a/bookie/bcelery/celery.py
+++ b/bookie/bcelery/celery.py
@@ -57,6 +57,10 @@ celery.conf.update(
             'task': 'bookie.bcelery.tasks.fetch_unfetched_bmark_content',
             'schedule': timedelta(seconds=60*60),
         },
+        'fulltext_missing': {
+            'task': 'bookie.bcelery.tasks.missing_fulltext_index',
+            'schedule': timedelta(seconds=60),
+        },
     }
 )
 

--- a/bookie/models/fulltext.py
+++ b/bookie/models/fulltext.py
@@ -88,6 +88,20 @@ class WhooshFulltext(object):
     """
     global WIX
 
+    def doc_count(self):
+        with WIX.searcher() as search:
+            return search.doc_count()
+
+    def findByID(self, bid):
+        """Find the item in the fulltext index by id"""
+        with WIX.searcher() as search:
+            found = search.documents(bid=unicode(bid))
+            res = [b for b in found]
+        if res:
+            return res[0]
+        else:
+            return None
+
     def search(self, phrase, content=False, username=None, ct=10, page=0,
                requested_by=None):
         """Implement the search, returning a list of bookmarks"""

--- a/bookie/static/js/bookie/view.js
+++ b/bookie/static/js/bookie/view.js
@@ -1032,6 +1032,9 @@ YUI.add('bookie-view', function (Y) {
                         data.count);
                     cont.one('#bookmark_stats_unique_count').setContent(
                         data.unique_count);
+                    cont.one('#bookmark_stats_fulltext_count').setContent(
+                        data.in_fulltext);
+
                     cont.one('#bookmark_stats_msg').setContent('');
                 },
                 error: function (data, status_str, response, args) {

--- a/bookie/templates/stats/dashboard.mako
+++ b/bookie/templates/stats/dashboard.mako
@@ -25,6 +25,11 @@
         <span class="label">Unique Urls:</span>
         <span id="bookmark_stats_unique_count"></span>
     </li>
+    <li>
+        <span class="label">Fulltext Urls:</span>
+        <span id="bookmark_stats_fulltext_count"></span>
+    </li>
+
 </ul>
 </div>
 <%def name="add_js()">

--- a/bookie/views/api.py
+++ b/bookie/views/api.py
@@ -80,9 +80,12 @@ def bookmark_stats(request):
     """Return all the bookmark stats"""
     bookmark_count = BmarkMgr.count()
     unique_url_count = BmarkMgr.count(distinct=True)
+    search = get_fulltext_handler(None)
+
     return _api_response(request, {
         'count': bookmark_count,
-        'unique_count': unique_url_count
+        'unique_count': unique_url_count,
+        'in_fulltext': search.doc_count()
     })
 
 


### PR DESCRIPTION
- Add fulltext numbers to the dashboard to help identity problems.
- Add a celery job to search for bookmarks missing from fulltext and add them
- Celery job grabs 500 bookmarks every 10minutes.
