### PR TITLE
Support hosting under a domain subpath (eg. example.org/bookie)

### DIFF
--- a/bookie/templates/accounts/index.mako
+++ b/bookie/templates/accounts/index.mako
@@ -3,6 +3,8 @@
 <%namespace file="func.mako" import="account_nav, password_reset"/>
 <%
     date_fmt = "%m/%d/%Y"
+    app_url = request.route_url('home').rstrip('/')
+    app_path = request.route_path('home').rstrip('/')
 %>
 ${account_nav()}
 
@@ -102,7 +104,7 @@ ${account_nav()}
 ${password_reset(user, reset=False)}
 
 <div class="form">
-    <div class="heading"><img src="/static/images/logo.128.svg" style="height: 16px; padding: 0 5px;" alt="Bookie Extensions"/>Extensions</div>
+    <div class="heading"><img src="${app_path}/static/images/logo.128.svg" style="height: 16px; padding: 0 5px;" alt="Bookie Extensions"/>Extensions</div>
     <p>We have browser extensions that work with Bookie for:</p>
     <ul>
         <li><a href="https://chrome.google.com/webstore/detail/knnbmilfpmbmlglpeemajjkelcbaaega">Google Chrome</a></li>
@@ -118,14 +120,14 @@ ${password_reset(user, reset=False)}
     from other browsers.
 
      <div><a title="Bookmark with Bookie" href="javascript:(function() {
-        location.href='${request.host_url}/${request.user.username}/new?url='+encodeURIComponent(location.href)+'&description='+encodeURIComponent(document.title)}())">Bookmark to Bookie</a></div>
+        location.href='${app_url}/${request.user.username}/new?url='+encodeURIComponent(location.href)+'&description='+encodeURIComponent(document.title)}())">Bookmark to Bookie</a></div>
 
     <div style="padding-top: 1em;">
         <a href="" id="show_bookmarklet" title="show bookmarklet code">Show
         Bookmarklet code</a> <div>(Handy for Android and other browsers that can't
                 save a link direct to bookmark.)</div>
         <br />
-        <textarea style="display: none; opacity: 0; width: 25em; height: 8em; padding: 1em; margin-top: 1em;" id="bookmarklet_text">javascript:(function() {location.href='${request.host_url}/${request.user.username}/new?url='+encodeURIComponent(location.href)+'&description='+encodeURIComponent(document.title)}())</textarea>
+        <textarea style="display: none; opacity: 0; width: 25em; height: 8em; padding: 1em; margin-top: 1em;" id="bookmarklet_text">javascript:(function() {location.href='${app_url}/${request.user.username}/new?url='+encodeURIComponent(location.href)+'&description='+encodeURIComponent(document.title)}())</textarea>
     </div>
     </p>
 </div>

--- a/bookie/templates/auth/signup.mako
+++ b/bookie/templates/auth/signup.mako
@@ -1,5 +1,8 @@
 <%inherit file="/main_wrap.mako" />
 <%def name="title()">Sign up for Bookie!</%def>
+<%
+    app_path = request.route_path('home').rstrip('/')
+%>
 <div class="form">
     <p>
         <a href="" id="signup_heading" class="heading">
@@ -15,7 +18,7 @@
         % else:
             <p>If you'd like to have an account please submit your email address
             and we'll send you an email in our next wave of sign ups.</p>
-            <form id="#signup_form" action="signup_process" method="POST">
+            <form id="#signup_form" action="${app_path}/signup_process" method="POST">
                 <ul>
                     <li>
                         <label>Email Address</label>

--- a/bookie/templates/bmark/confirm_delete.mako
+++ b/bookie/templates/bmark/confirm_delete.mako
@@ -8,6 +8,6 @@
     <p><em>${bmark_description}</em></p>
     <input type="hidden" id="bid" name="bid" value="${bid}" />
     <!-- ew, onclick. This page will be replaced by a nice ajaxy delete confirmation, so it's ok. -->
-    <input id="cancel" type="button" value="Cancel" style="padding:2px;margin-right:40px" onclick="location.href='/'" />
+    <input id="cancel" type="button" value="Cancel" style="padding:2px;margin-right:40px" onclick="location.href='${app_url}'" />
     <input id="delete" type="submit" value="Delete" style="padding:2px;" />
 </form>

--- a/bookie/templates/bmark/recent.mako
+++ b/bookie/templates/bmark/recent.mako
@@ -26,10 +26,10 @@ import json
 
             % if username:
                 var resource_username = '${username}';
-                var route = resource_username + '/recent';
+                var route = APP_PATH + resource_username + '/recent';
             % else:
                 var resource_username = undefined;
-                var route = '/recent';
+                var route = APP_PATH + '/recent';
             % endif
 
             var pager = new Y.bookie.PagerModel();

--- a/bookie/templates/index.mako
+++ b/bookie/templates/index.mako
@@ -1,11 +1,14 @@
 <%inherit file="/main_wrap.mako" />
 <%def name="title()">Welcome to Bookie</%def>
+<%
+    app_path = request.route_path('home').rstrip('/')
+%>
 
 <div id="welcome" class="" style="max-width: 1000px;">
     <div class="signup">
         <div class="form">
             <h2>Enter Email to Signup</h2>
-            <form id="#signup_form" action="signup_process" method="POST">
+            <form id="#signup_form" action="${app_path}/signup_process" method="POST">
                 <ul>
                     <li>
                         <input type="email" id="email" name="email"

--- a/bookie/templates/jstpl.mako
+++ b/bookie/templates/jstpl.mako
@@ -1,3 +1,6 @@
+<%
+    app_path = request.route_path('home').rstrip('/')
+%>
 <script type="text/template" id="bmark_row">
     <div class="tags">
         {{#each tags}}
@@ -7,9 +10,9 @@
 
     <div class="description">
     {{#if username}}
-        <a href="/{{username}}/redirect/{{hash_id}}"
+        <a href="${app_path}/{{username}}/redirect/{{hash_id}}"
     {{else}}
-        <a href="/redirect/{{hash_id}}"
+        <a href="${app_path}/redirect/{{hash_id}}"
     {{/if}}
             title="{{extended}}">
             <img class="favicon" src="https://s2.googleusercontent.com/s2/favicons?domain={{domain}}" />
@@ -27,7 +30,7 @@
     <div class="actions">
         <span class="days-ago">{{prettystored}}</span>
 
-        <a href="/bmark/readable/{{hash_id}}"
+        <a href="${app_path}/bmark/readable/{{hash_id}}"
            title="View readable content"
            alt="View readable content"
            class="readable">
@@ -36,7 +39,7 @@
         </a>
 
         {{#if owner}}
-            <a href="/{{username}}/edit/{{hash_id}}"
+            <a href="${app_path}/{{username}}/edit/{{hash_id}}"
                 title="Edit the bookmark" alt="Edit the bookmark"
                 class="edit">
                 <span aria-hidden="true" class="icon icon-pencil"></span>
@@ -52,11 +55,11 @@
     </div>
     {{#unless owner}}
         <div class="user">
-            <a href="/{{username}}/recent" title="View {{username}}'s bookmarks">{{username}}</a>
+            <a href="${app_path}/{{username}}/recent" title="View {{username}}'s bookmarks">{{username}}</a>
         </div>
     {{/unless}}
     <div class="url" title="{{url}}">
-        <a href="/bmark/readable/{{hash_id}}"
+        <a href="${app_path}/bmark/readable/{{hash_id}}"
            title="View readable content" alt="View readable content">
            <span aria-hidden="true" class="icon icon-eye-open"></span>
            <em class="icon">View readable content</em>
@@ -88,7 +91,7 @@
 
         {{#if current_user}}
             <div class="buttons add" style="display: inline-block; vertical-align: middle;">
-                <a href="/{{current_user}}/new"
+                <a href="${app_path}/{{current_user}}/new"
                     class="button">
                     <span class="icon icon-plus"
                     aria-hidden="true"></span> <span class="desc">Add Bookmark</span>
@@ -154,11 +157,11 @@
             <span aria-hidden="true" class="icon icon-share" title="import your bookmarks"></span>
             <em class="icon">import your bookmarks</em>
             You can import your bookmarks from Delicious or Google Bookmarks by going to
-            the <a href="/{{username}}/import">import page</a>.
+            the <a href="${app_path}/{{username}}/import">import page</a>.
         </p>
 
         <p>
-        <img src="/static/images/logo.128.svg" style="height: 32px; padding: 0
+        <img src="${app_path}/static/images/logo.128.svg" style="height: 32px; padding: 0
         5px;" alt="Google Chrome Extension"/> You might want to get a hold of the <a
         href="https://chrome.google.com/webstore/detail/knnbmilfpmbmlglpeemajjkelcbaaega">extension
         for Google Chrome</a> which will help you save pages to your Bookie

--- a/bookie/templates/main_wrap.mako
+++ b/bookie/templates/main_wrap.mako
@@ -2,6 +2,8 @@
     date_fmt = "%m/%d/%Y"
     combo = request.registry.settings['combo_server']
     cache_buster = request.registry.settings['combo_cache_id']
+    app_url = request.route_url('home').rstrip('/')
+    app_path = request.route_path('home').rstrip('/')
 %>
 <!DOCTYPE html>
 <html>
@@ -9,7 +11,7 @@
         <meta http-equiv="X-UA-Compatible" content="IE=8" />
         <meta name="viewport" content="width=device-width initial-scale=1.0">
         <meta name="mobile-web-app-capable" content="yes">
-        <link rel="shortcut icon" sizes="196x196" href="/static/images/logo.196.png">
+        <link rel="shortcut icon" sizes="196x196" href="${app_path}/static/images/logo.196.png">
         <title>Bookie: ${self.title()}</title>
         <script type="text/javascript"
         src="${combo}/combo?y/yui/yui-min.js&b/meta.js&y/loader/loader-min.js&y/substitute/substitute-min.js"></script>
@@ -19,7 +21,7 @@
         <link
             href='https://fonts.googleapis.com/css?family=Cabin|Cabin+Sketch:bold&v2'
             rel='stylesheet' type='text/css'/>
-        <link rel="stylesheet" type="text/css" href="/static/css/responsive.css"/>
+        <link rel="stylesheet" type="text/css" href="${app_path}/static/css/responsive.css"/>
         <script type="text/javascript">
             YUI.GlobalConfig = {
                 combine: true,
@@ -46,10 +48,9 @@
         % endif
 
         <script type="text/javascript" charset="utf-8">
-            <%
-                app_url = request.route_url('home').rstrip('/')
-            %>
+
             APP_URL = '${app_url}';
+            APP_PATH = '${app_path}';
 
         </script>
     </head>
@@ -62,7 +63,7 @@
             </div>
             <div class="navigation">
                 <span class="item">
-                    <a href="/recent" class="button nav_button">
+                    <a href="${app_path}/recent" class="button nav_button">
                         <span aria-hidden="true" class="icon icon-tags" title="All Bookmarks"></span>
                         <em class="icon">All Bookmarks</em>
                         <span class="text">All</span>
@@ -71,7 +72,7 @@
 
                 % if request.user:
                     <span class="item">
-                        <a href="/${request.user.username}/recent" class="button nav_button">
+                        <a href="${app_path}/${request.user.username}/recent" class="button nav_button">
                             <span aria-hidden="true" class="icon icon-tag"
                             title="My Bookmarks"></span>
                             <em class="icon">My Bookmarks</em>
@@ -81,7 +82,7 @@
                 % endif
 
                 <span class="item">
-                    <a href="/search" class="button nav_button">
+                    <a href="${app_path}/search" class="button nav_button">
                         <span aria-hidden="true" class="icon icon-search" title="Search"></span>
                         <em class="icon">Search</em>
                         <span class="text">Search</span>
@@ -103,7 +104,7 @@
                     </a></span>
                 % else:
                     <span class="item">
-                        <a href="/login" class="button nav_button">
+                        <a href="${app_path}/login" class="button nav_button">
                             <span aria-hidden="true" class="icon icon-user" title="Login"></span>
                             <em class="icon">Login</em>
                             <span class="text">Login</span>
@@ -129,9 +130,9 @@
             <div class="yui3-u-1-4"></div>
             <div class="yui3-u-3-4">
                 <div class="right body">
-                    <a href="/recent?sort=popular">All Popular Bookmarks</a> |
+                    <a href="${app_path}/recent?sort=popular">All Popular Bookmarks</a> |
                     % if request.user and request.user.username:
-                        <a href="/${request.user.username}/recent?sort=popular">My Popular Bookmarks</a> |
+                        <a href="${app_path}/${request.user.username}/recent?sort=popular">My Popular Bookmarks</a> |
                     % endif
                     <a href="http://docs.bmark.us">Bookie</a> |
                     <a href="http://github.com/bookieio/Bookie/issues">Support</a> |


### PR DESCRIPTION
This adds support for hosting Bookie on a subdomain. Some things still
don't work quite right (ie. sometimes the slash after `bookie` in
`example.org.bookie` is lost) but that's not frequent enough to be a
blocker in my opinion.

We have been using this in production for months without much problem
except the above now.
