### PR TITLE
[issue #547] fixed decoding issue of bookmark title

### DIFF
--- a/bookie/lib/importer.py
+++ b/bookie/lib/importer.py
@@ -10,7 +10,7 @@ from dateutil import parser as dateparser
 from BeautifulSoup import BeautifulSoup
 from lxml import etree
 from lxml.etree import XMLSyntaxError
-
+from HTMLParser import HTMLParser
 from bookie.lib.urlhash import generate_hash
 from bookie.models import (
     BmarkMgr,
@@ -167,6 +167,7 @@ class DelImporter(Importer):
     def process(self):
         """Given a file, process it"""
         soup = BeautifulSoup(self.file_handle)
+        htmlParser = HTMLParser()
         count = 0
 
         ids = []
@@ -196,7 +197,7 @@ class DelImporter(Importer):
             try:
                 bmark = self.save_bookmark(
                     unicode(link['href']),
-                    unicode(link.text),
+                    unicode(htmlParser.unescape(link.text)),
                     unicode(extended),
                     u" ".join(unicode(link.get('tags', '')).split(u',')),
                     dt=add_date,
@@ -377,6 +378,7 @@ class GBookmarkImporter(Importer):
         if not soup.contents[0] == "DOCTYPE NETSCAPE-Bookmark-file-1":
             raise Exception("File is not a google bookmarks file")
 
+        htmlParser = HTMLParser()
         urls = dict()  # url:url_metadata
 
         # we don't want to just import all the available urls, since each url
@@ -417,7 +419,7 @@ class GBookmarkImporter(Importer):
                             link['add_date'] = time.time()
 
                         urls[url] = {
-                            'description': link.text,
+                            'description': htmlParser.unescape(link.text),
                             'tags': tags,
                             'extended': extended,
                             'date_added': datetime.fromtimestamp(

--- a/bookie/tests/test_utils/delicious.html
+++ b/bookie/tests/test_utils/delicious.html
@@ -6,7 +6,7 @@
             <TITLE>Bookmarks</TITLE>
             <H1>Bookmarks</H1>
             <DL><p>
-<DT><A HREF="http://www.ndftz.com/nickelanddime.png" LAST_VISIT="1298664780" ADD_DATE="1298664780000" TAGS="canonical,banshee,ubuntu-one,ubuntu,amazon,kerfuffle,nickelanddime">nickelanddime.png (PNG Image, 1200x1400 pixels) - Scaled (64%)</A>
+<DT><A HREF="http://www.ndftz.com/nickelanddime.png" LAST_VISIT="1298664780" ADD_DATE="1298664780000" TAGS="canonical,banshee,ubuntu-one,ubuntu,amazon,kerfuffle,nickelanddime">nickelanddime.png (PNG Image, 1200x1400 pixels) - Scaled (64%) - &#34;Test&#34;</A>
 <DD>This is the extended description
 <DT><A HREF="http://www.nature.com/news/2011/110223/full/470437a.html" LAST_VISIT="1298559624" ADD_DATE="1298559623" TAGS="open-access,open-data,open-source,reproducibility,decline-effect">Unpublished results hide the decline effect : Nature News</A>
 <DT><A HREF="http://diyubook.com/2011/02/announcing-my-next-project-the-edupunks-guide-to-a-diy-credential/comment-page-1/#comment-4386" LAST_VISIT="1298522114" ADD_DATE="1298522114" TAGS="edupunk,diyu,oer,ocw,openeducation,creativecommons,gatesfoundation">Announcing my Next Project: The Edupunk’s Guide to a DIY Credential » DIY U</A>

--- a/bookie/tests/test_utils/googlebookmarks.html
+++ b/bookie/tests/test_utils/googlebookmarks.html
@@ -21,7 +21,7 @@
 </DL><p>
 <DT><H3 ADD_DATE="1300383028360057">css</H3>
 <DL><p>
-<DT><A HREF="http://www.alistapart.com/" ADD_DATE="1300383028360057">A List Apart</A>
+<DT><A HREF="http://www.alistapart.com/" ADD_DATE="1300383028360057">A List Apart &quot;Test&quot;</A>
 <DD>For people who make websites
 </DL><p>
 <DT><H3 ADD_DATE="1300383028360057">html</H3>

--- a/bookie/tests/test_utils/test_imports.py
+++ b/bookie/tests/test_utils/test_imports.py
@@ -49,6 +49,8 @@ class TestImports(unittest.TestCase):
 
         # verify we can find a bookmark by url and check tags, etc
         check_url = u'http://www.ndftz.com/nickelanddime.png'
+        url_description = u'nickelanddime.png (PNG Image, 1200x1400 pixels)' \
+                          u' - Scaled (64%) - "Test"'
         check_url_hashed = generate_hash(check_url)
         found = Bmark.query.filter(Bmark.hash_id == check_url_hashed).one()
 
@@ -72,6 +74,12 @@ class TestImports(unittest.TestCase):
         self.assertTrue(
             "description" in found.extended,
             "The extended attrib should have a nice long string in it")
+
+        # verify html entities in descriptioin are decoded
+        self.assertEqual(
+            url_description,
+            found.description,
+            "The description of URL should not have any XML/HTML entities")
 
     def _delicious_xml_data_test(self):
         """Test that we find the correct google bmark data after import"""
@@ -120,6 +128,7 @@ class TestImports(unittest.TestCase):
         # verify we can find a bookmark by url and check tags, etc
         check_url = 'http://www.alistapart.com/'
         check_url_hashed = generate_hash(check_url)
+        url_description = u'A List Apart "Test"'
         found = Bmark.query.filter(Bmark.hash_id == check_url_hashed).one()
 
         self.assertTrue(
@@ -138,6 +147,12 @@ class TestImports(unittest.TestCase):
         self.assertTrue(
             "make websites" in found.extended,
             "'make websites' should be in the extended description")
+
+        # verify html entities in descriptioin are decoded
+        self.assertEqual(
+            url_description,
+            found.description,
+            "The description of URL should not have any XML/HTML entities")
 
     def _chrome_data_test(self):
         """Test that we find the correct Chrome bmark data after import"""


### PR DESCRIPTION
I have fixed the decoding issue. I have made changes in bookmark HTML files for testing.
lxml.etree decodes HTML/XML entities on its own. So, I didn't make any changes in the testcase. 

Please tell me if any changes are needed?
