### PR TITLE
Feature/authed starttls email out

### DIFF
--- a/bookie/bcelery/tasks.py
+++ b/bookie/bcelery/tasks.py
@@ -232,7 +232,7 @@ def email_signup_user(email, msg, settings, message_data):
     if status == 4:
         from bookie.lib.applog import SignupLog
         trans = transaction.begin()
-        SignupLog(SignupLog.ERROR,
+        SignupLog(email, SignupLog.ERROR,
                   'Could not send smtp email to signup: ' + email)
         trans.commit()
 

--- a/bookie/lib/applog.py
+++ b/bookie/lib/applog.py
@@ -131,10 +131,14 @@ class LogRecord(object):
 class SignupLog(object):
     """Signup Log records."""
 
-    def __init__(self, status, message, **kwargs):
+    ERROR = 0
+
+    def __init__(self, user, status, message, **kwargs):
         """A record in the log"""
+        kwargs['user'] = user
         kwargs['status'] = status
         kwargs['message'] = message
+        kwargs['component'] = u'SIGNUPLOG'
 
         # we need to hash down the payload if there is one
         if 'payload' in kwargs and kwargs['payload'] is not None:

--- a/bookie/lib/message.py
+++ b/bookie/lib/message.py
@@ -92,11 +92,20 @@ class Message(object):
             try:
                 all_emails = msg['To']
                 smtp_server = self.settings.get('email.host')
+                starttls = self.settings.get('email.starttls', False)
+                smtp_user = self.settings.get('email.smtp_user', None)
+                smtp_password = self.settings.get('email.smtp_password', None)
 
                 if smtp_server == 'sendmail':
                     sendmail(msg['To'], msg['From'], msg['Subject'], self.body)
                 else:
                     mail_server = smtplib.SMTP(smtp_server)
+                    if starttls:
+                        mail_server.starttls()
+
+                    if smtp_user is not None and smtp_password is not None:
+                        mail_server.login(smtp_user, smtp_password)
+
                     mail_server.sendmail(msg['From'],
                                          all_emails,
                                          msg.as_string())


### PR DESCRIPTION
Allows outgoing signup emails to be sent with starttls and user/pass authentication for smtp.

Also fix signup logging.
